### PR TITLE
switched to ubuntu:latest base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,18 @@
-FROM python:3.7
+FROM ubuntu:latest
+
+RUN apt-get update \
+  && apt-get install -y git \
+  && apt-get install -y python3-pip python3-dev \
+  && cd /usr/local/bin \
+  && ln -s /usr/bin/python3 python \
+  && pip3 install --upgrade pip
 
 COPY requirements.txt ./
 RUN pip3 install --no-cache-dir -r requirements.txt
 
 COPY cucumber-format.patch /tmp/
 RUN \
-     cd /usr/local/lib/python3*/site-packages/behave/formatter \
+     cd /usr/local/lib/python3*/dist-packages/behave/formatter \
   && patch -p1 < /tmp/cucumber-format.patch
 
 VOLUME /workspace


### PR DESCRIPTION
Python but explicitly installed over ubuntu latest. Gets around the debian ssl issues. Might be a cleaner way but this seems to work.

note - I think this is python 3.6