### PR TITLE
added python-box to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,7 @@ pyexcel-ods3==0.5.3
 pyexcel-odsr==0.5.2
 pyexcel-xls==0.5.8
 pyexcel-text==0.2.7.1
+python-box==3.4.5
 html2text==2018.1.9
 git+https://github.com/GSS-Cogs/gss-utils.git@v0.5.5
 chardet==3.0.4


### PR DESCRIPTION

any chance we can add this?

it's a python library for constructing dictionaries with dot notation:

`["typing"]["out"]["all"]["those"]`

can be

`typing.out.all.those`

super useful for keeping things clean when you're using dictionaries a lot (I'm thinking for per-tab params, that can get messy otherwise).