### PR TITLE
canwaf/dev-unity

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ COPY Pipfile Pipfile.lock ./
 ENV PIP_NO_CACHE_DIR=false
 RUN pip install pipenv
 
-RUN if [ -z "$dev" ] ; \
+RUN if [ -z "${dev}" ] ; \
     then \
         pipenv install --system; \
     else \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,20 @@ FROM python:3.8
 
 ENV PIPENV_TIMEOUT=36000 
 
+ARG dev
+
 COPY Pipfile Pipfile.lock ./
 ENV PIP_NO_CACHE_DIR=false
 RUN pip install pipenv
-RUN pipenv install --system
+
+RUN if [ -z "$dev" ] ; \
+    then \
+        pipenv install --system; \
+    else \
+        pipenv install --system --dev && \
+        apt-get update && \
+        apt-get install gnupg2 -y; \
+    fi
 
 COPY cucumber-format.patch /tmp/
 RUN cd /usr/local/lib/python3*/site-packages/behave/formatter \

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,14 +8,9 @@ COPY Pipfile Pipfile.lock ./
 ENV PIP_NO_CACHE_DIR=false
 RUN pip install pipenv
 
-RUN if [ -z "${dev}" ] ; \
-    then \
-        pipenv install --system; \
-    else \
-        pipenv install --system --dev && \
-        apt-get update && \
-        apt-get install gnupg2 -y; \
-    fi
+RUN pipenv install --system --dev
+
+RUN apt-get update && apt-get install gnupg2 -y
 
 COPY cucumber-format.patch /tmp/
 RUN cd /usr/local/lib/python3*/site-packages/behave/formatter \


### PR DESCRIPTION
When generating the docker container passing `--build-arg dev=True` will now install the development packages from the pipfile (namely pylint), and also install gnupg2 (to allow code signing). A second autobuild of tag:latest (i.e. `tag:latest-dev`) will allow for smoother IDE config for developers.