### PR TITLE
Use 'sync' instead of 'install' for repeatable builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ENV PIPENV_TIMEOUT=36000
 COPY Pipfile Pipfile.lock ./
 ENV PIP_NO_CACHE_DIR=false
 RUN pip install pipenv
-RUN pipenv install --system
+RUN pipenv sync --system
 
 COPY cucumber-format.patch /tmp/
 RUN cd /usr/local/lib/python3*/site-packages/behave/formatter \


### PR DESCRIPTION
Need to with Docker Hub to see whether this helps.